### PR TITLE
getBarrelFileReferencesInFile now no longer returns exports from other packages

### DIFF
--- a/src/getBarrelFileReferencesInFile.test.ts
+++ b/src/getBarrelFileReferencesInFile.test.ts
@@ -34,7 +34,6 @@ describe('getBarrelFileReferencesInFile tests', () => {
       '/index.ts': `
       export { test } from "./test";
       export { barrelFileReference } from "./barrelFileReference";
-      export { reExportFromExternalPackage } from "react";
       `,
       '/test.ts': 'export const test = 1;',
       '/barrelFileReference/index.ts':
@@ -49,7 +48,20 @@ describe('getBarrelFileReferencesInFile tests', () => {
 
     assert.deepEqual(getBarrelFileReferencesInFile('/index.ts'), [
       { barrelFilePath: './barrelFileReference/index.ts' },
-      { barrelFilePath: 'react' },
     ]);
+  });
+
+  it('does not return references to external packages', () => {
+    mock({
+      '/index.ts': `
+      export { useEffect } from "react";
+      export { createRoot } from "./createRoot";
+      `,
+      '/createRoot.ts': `
+      export { createRoot } from "react-dom/client";`,
+      './node_modules': mock.load('node_modules'),
+    });
+
+    assert.deepEqual(getBarrelFileReferencesInFile('/index.ts'), []);
   });
 });


### PR DESCRIPTION
For the purposes I need right now, we don't care if the re-export is from an external package. Only consider internal modules